### PR TITLE
Added US_ASCII to the osx_app.rb file.

### DIFF
--- a/lib/releasy/builders/osx_app.rb
+++ b/lib/releasy/builders/osx_app.rb
@@ -182,7 +182,7 @@ OSX_EXECUTABLE_FOLDER = File.expand_path("../../..", __FILE__)
 
 # Really hacky fudge-fix for something oddly missing in the .app.
 class Encoding
-  BINARY = UTF_8 = UTF_7 = UTF_16BE = UTF_16LE = UTF_32BE = UTF_32LE = Encoding.list.first
+  BINARY = UTF_8 = UTF_7 = UTF_16BE = UTF_16LE = UTF_32BE = UTF_32LE = US_ASCII = Encoding.list.first
 end
 
 Dir.chdir 'application'

--- a/test/releasy/builders/data/Main.rb
+++ b/test/releasy/builders/data/Main.rb
@@ -10,7 +10,7 @@ OSX_EXECUTABLE_FOLDER = File.expand_path("../../..", __FILE__)
 
 # Really hacky fudge-fix for something oddly missing in the .app.
 class Encoding
-  BINARY = UTF_8 = UTF_7 = UTF_16BE = UTF_16LE = UTF_32BE = UTF_32LE = Encoding.list.first
+  BINARY = UTF_8 = UTF_7 = UTF_16BE = UTF_16LE = UTF_32BE = UTF_32LE = US_ASCII = Encoding.list.first
 end
 
 Dir.chdir 'application'


### PR DESCRIPTION
I kept running into another issue with encodings on OSX which was fixed by adding US_ASCII. I added it to the osx_app.rb file and the test data for osx. Ive been using releasy quite a bit lately updating my game ;) Its been a God send other than having to update the Main.rb file for OSX every time. Not sure what need to be done to update the gem, but let me know when you get a newer version out!
