### PR TITLE
command_available? returns false if command is not found

### DIFF
--- a/lib/releasy/mixins/utilities.rb
+++ b/lib/releasy/mixins/utilities.rb
@@ -47,7 +47,8 @@ module Releasy
         find = Releasy.win_platform? ? "where" : "which"
         # Call this Kernel version of `` so it can be mocked in testing.
         result = Kernel.`("#{find} #{command}")
-        !result.strip.empty?
+        return false unless $? == 0
+        result
       end
 
       protected


### PR DESCRIPTION
This fixes seven_zip_command, it was relying on command_available to return a bool not a string.
